### PR TITLE
added CSV reshaping for SoftDrop subjets of AK8

### DIFF
--- a/plugins/JetAnalyzer.cc
+++ b/plugins/JetAnalyzer.cc
@@ -128,6 +128,19 @@ std::vector<pat::Jet> JetAnalyzer::FillJetVector(const edm::Event& iEvent) {
             jet.addUserFloat("ak8PFJetsCHSSoftDropPuppiMass", puppiSoftdrop.M());
         }
         
+        // CSV reshaping for soft drop subjets
+        if(jet.hasSubjets("SoftDrop")) {
+            auto const & sdSubjets = jet.subjets("SoftDrop");
+            short nsj = 1;
+            for (auto const & it : sdSubjets) {
+                pat::Jet subjet = it;
+                jet.addUserFloat(Form("ReshapedDiscriminator%d",nsj), reshapeBtagDiscriminator(subjet)[0]);
+                jet.addUserFloat(Form("ReshapedDiscriminatorUp%d",nsj), reshapeBtagDiscriminator(subjet)[1]);
+                jet.addUserFloat(Form("ReshapedDiscriminatorDown%d",nsj), reshapeBtagDiscriminator(subjet)[2]);
+                ++nsj;
+            }
+        }
+                
         // Mass correction
         if(RecalibrateMass) {
             float jec = Corrector->correction(jet);

--- a/plugins/JetAnalyzer.h
+++ b/plugins/JetAnalyzer.h
@@ -29,6 +29,8 @@
 
 #include "BTagCalibrationStandalone.h"
 
+#include "DataFormats/Common/interface/Ptr.h"
+
 #include "TFile.h"
 #include "TH2.h"
 #include "TLorentzVector.h"

--- a/plugins/Objects.h
+++ b/plugins/Objects.h
@@ -111,7 +111,7 @@ struct JetType {
 
 
 struct FatJetType {
-FatJetType(): pt(-1.), eta(-9.), phi(-9.), mass(-1.), energy(-1.), ptRaw(-1.), ptUnc(-1.), dPhi_met(-1.), dPhi_jet1(-1.), puId(-1.), CSV(-99.), CSVR(-99.), CSVRUp(-99.), CSVRDown(-99.), chf(-1.), nhf(-1.), phf(-1.), elf(-1.), muf(-1.), chm(-1), npr(-1), flavour(0), mother(0), isLoose(false), isMedium(false), isTight(false), isTightLepVeto(false), isMatched(false), prunedMass(-1.), softdropMass(-1.), softdropPuppiMass(-1.), prunedMassCorr(-1.), softdropMassCorr(-1.), softdropPuppiMassCorr(-1.), pt1(-1.), eta1(-9.), phi1(-9.), mass1(-1.), CSV1(-99.), CSVR1(-99.), flavour1(-1.), pt2(-1.), eta2(-9.), phi2(-9.), mass2(-1.), CSV2(-99.), CSVR2(-99.), flavour2(-1.), dR(-1.), tau21(-1.) {}
+FatJetType(): pt(-1.), eta(-9.), phi(-9.), mass(-1.), energy(-1.), ptRaw(-1.), ptUnc(-1.), dPhi_met(-1.), dPhi_jet1(-1.), puId(-1.), CSV(-99.), CSVR(-99.), CSVRUp(-99.), CSVRDown(-99.), chf(-1.), nhf(-1.), phf(-1.), elf(-1.), muf(-1.), chm(-1), npr(-1), flavour(0), mother(0), isLoose(false), isMedium(false), isTight(false), isTightLepVeto(false), isMatched(false), prunedMass(-1.), softdropMass(-1.), softdropPuppiMass(-1.), prunedMassCorr(-1.), softdropMassCorr(-1.), softdropPuppiMassCorr(-1.), pt1(-1.), eta1(-9.), phi1(-9.), mass1(-1.), CSV1(-99.), CSVR1(-99.), CSVRUp1(-99.), CSVRDown1(-99.), flavour1(-1.), pt2(-1.), eta2(-9.), phi2(-9.), mass2(-1.), CSV2(-99.), CSVR2(-99.), CSVRUp2(-99.), CSVRDown2(-99.), flavour2(-1.), dR(-1.), tau21(-1.) {}
     float pt;
     float eta;
     float phi;
@@ -152,6 +152,8 @@ FatJetType(): pt(-1.), eta(-9.), phi(-9.), mass(-1.), energy(-1.), ptRaw(-1.), p
     float mass1;
     float CSV1;
     float CSVR1;
+    float CSVRUp1;
+    float CSVRDown1;
     float flavour1;
     float pt2;
     float eta2;
@@ -159,6 +161,8 @@ FatJetType(): pt(-1.), eta(-9.), phi(-9.), mass(-1.), energy(-1.), ptRaw(-1.), p
     float mass2;
     float CSV2;
     float CSVR2;
+    float CSVRUp2;
+    float CSVRDown2;
     float flavour2;
     float dR;
     float tau21;

--- a/plugins/ObjectsFormat.cc
+++ b/plugins/ObjectsFormat.cc
@@ -334,6 +334,7 @@ void ObjectsFormat::FillFatJetType(FatJetType& I, const pat::Jet* R, bool isMC) 
     I.dPhi_met    = R->hasUserFloat("dPhi_met") ? R->userFloat("dPhi_met") : -1.;
     I.dPhi_jet1   = R->hasUserFloat("dPhi_jet1") ? R->userFloat("dPhi_jet1") : -1.;
     I.puId        = -1.; //R->userFloat("pileupJetId:fullDiscriminant");
+    I.CSV         = R->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
     I.CSVR        = R->hasUserFloat("ReshapedDiscriminator") ? R->userFloat("ReshapedDiscriminator") : R->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
     I.CSVRUp      = R->hasUserFloat("ReshapedDiscriminatorUp") ? R->userFloat("ReshapedDiscriminatorUp") : R->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
     I.CSVRDown    = R->hasUserFloat("ReshapedDiscriminatorDown") ? R->userFloat("ReshapedDiscriminatorDown") : R->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
@@ -383,14 +384,18 @@ void ObjectsFormat::FillFatJetType(FatJetType& I, const pat::Jet* R, bool isMC) 
     I.phi1        = R->subjets("SoftDrop").size() > 0 ? R->subjets("SoftDrop")[0]->phi() : -1.;
     I.mass1       = R->subjets("SoftDrop").size() > 0 ? R->subjets("SoftDrop")[0]->mass() : -1.;
     I.CSV1        = R->subjets("SoftDrop").size() > 0 ? R->subjets("SoftDrop")[0]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") : -1.;
-    I.CSVR1       = R->subjets("SoftDrop").size() > 0 ? R->subjets("SoftDrop")[0]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") : -1.;
+    I.CSVR1       = (R->subjets("SoftDrop").size() > 0 && R->hasUserFloat("ReshapedDiscriminator1")) ? R->userFloat("ReshapedDiscriminator1") : R->subjets("SoftDrop")[0]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+    I.CSVRUp1     = (R->subjets("SoftDrop").size() > 0 && R->hasUserFloat("ReshapedDiscriminatorUp1")) ? R->userFloat("ReshapedDiscriminatorUp1") : R->subjets("SoftDrop")[0]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+    I.CSVRDown1   = (R->subjets("SoftDrop").size() > 0 && R->hasUserFloat("ReshapedDiscriminatorDown1")) ? R->userFloat("ReshapedDiscriminatorDown1") : R->subjets("SoftDrop")[0]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
     I.flavour1    = R->subjets("SoftDrop").size() > 0 ? R->subjets("SoftDrop")[0]->hadronFlavour() : -1.;
     I.pt2         = R->subjets("SoftDrop").size() > 1 ? R->subjets("SoftDrop")[1]->pt() : -1.;
     I.eta2        = R->subjets("SoftDrop").size() > 1 ? R->subjets("SoftDrop")[1]->eta() : -1.;
     I.phi2        = R->subjets("SoftDrop").size() > 1 ? R->subjets("SoftDrop")[1]->phi() : -1.;
     I.mass2       = R->subjets("SoftDrop").size() > 1 ? R->subjets("SoftDrop")[1]->mass() : -1.;
     I.CSV2        = R->subjets("SoftDrop").size() > 1 ? R->subjets("SoftDrop")[1]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") : -1.;
-    I.CSVR2       = R->subjets("SoftDrop").size() > 1 ? R->subjets("SoftDrop")[1]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") : -1.;
+    I.CSVR2       = (R->subjets("SoftDrop").size() > 1 && R->hasUserFloat("ReshapedDiscriminator2")) ? R->userFloat("ReshapedDiscriminator2") : R->subjets("SoftDrop")[1]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+    I.CSVRUp2     = (R->subjets("SoftDrop").size() > 1 && R->hasUserFloat("ReshapedDiscriminatorUp2")) ? R->userFloat("ReshapedDiscriminatorUp2") : R->subjets("SoftDrop")[1]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+    I.CSVRDown2   = (R->subjets("SoftDrop").size() > 1 && R->hasUserFloat("ReshapedDiscriminatorDown2")) ? R->userFloat("ReshapedDiscriminatorDown2") : R->subjets("SoftDrop")[1]->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
     I.flavour2    = R->subjets("SoftDrop").size() > 1 ? R->subjets("SoftDrop")[1]->hadronFlavour() : -1.;
     I.dR          = R->subjets("SoftDrop").size() > 1 ? deltaR(*R->subjets("SoftDrop")[0], *R->subjets("SoftDrop")[1]) : -1.;
     I.tau21       = R->userFloat("NjettinessAK8:tau1") != 0 ? R->userFloat("NjettinessAK8:tau2")/R->userFloat("NjettinessAK8:tau1") : -1.;
@@ -449,7 +454,7 @@ void ObjectsFormat::ResetFatJetType(FatJetType& I) {
     I.tau21       = -1.;
 }
 
-std::string ObjectsFormat::ListFatJetType() {return "pt/F:eta/F:phi/F:mass/F:energy/F:ptRaw/F:ptUnc/F:dPhi_met/F:dPhi_jet1/F:puId/F:CSV/F:CSVR/F:CSVRUp/F:CSVRDown/F:chf/F:nhf/F:phf/F:elf/F:muf/F:chm/I:npr/I:flavour/I:mother/I:isLoose/O:isMedium/O:isTight/O:isTightLepVeto/O:isCSVL/O:isCSVM/O:isCSVT/O:isMatched/O:prunedMass/F:softdropMass/F:softdropPuppiMass/F:prunedMassCorr/F:softdropMassCorr/F:softdropPuppiMassCorr/F:pt1/F:eta1/F:phi1/F:mass1/F:CSV1/F:CSVR1/F:flavour1/F:pt2/F:eta2/F:phi2/F:mass2/F:CSV2/F:CSVR2/F:flavour2/F:dR/F:tau21/F";}
+std::string ObjectsFormat::ListFatJetType() {return "pt/F:eta/F:phi/F:mass/F:energy/F:ptRaw/F:ptUnc/F:dPhi_met/F:dPhi_jet1/F:puId/F:CSV/F:CSVR/F:CSVRUp/F:CSVRDown/F:chf/F:nhf/F:phf/F:elf/F:muf/F:chm/I:npr/I:flavour/I:mother/I:isLoose/O:isMedium/O:isTight/O:isTightLepVeto/O:isCSVL/O:isCSVM/O:isCSVT/O:isMatched/O:prunedMass/F:softdropMass/F:softdropPuppiMass/F:prunedMassCorr/F:softdropMassCorr/F:softdropPuppiMassCorr/F:pt1/F:eta1/F:phi1/F:mass1/F:CSV1/F:CSVR1/F:CSVRUp1/F:CSVRDown1/F:flavour1/F:pt2/F:eta2/F:phi2/F:mass2/F:CSV2/F:CSVR2/F:CSVRUp2/F:CSVRDown2/F:flavour2/F:dR/F:tau21/F";}
 
 
 


### PR DESCRIPTION
still to understand which is the official way to handle all the systematics listed in the csv file.
currently using only up_jes/down_jes
