### PR TITLE
new instructions and modified Buildfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cd CMSSW_8_0_12/src/
 cmsenv
 git cms-init
 ```
-Merge the most recent MET filters and EGM smearing and scale
+Merge the most recent MET filters and EGM smearing, scale, and IDs
 ```bash
 git cms-merge-topic -u cms-met:CMSSW_8_0_X-METFilterUpdate
 git cms-merge-topic -u emanueledimarco:ecal_smear_fix_80X
@@ -17,6 +17,7 @@ git cms-addpkg EgammaAnalysis/ElectronTools
 cd EgammaAnalysis/ElectronTools/data
 git clone -b ICHEP2016_approval_7p65fb https://github.com/emanueledimarco/ScalesSmearings.git
 cd $CMSSW_BASE/src
+git cms-merge-topic -u ikrav:egm_id_80X_v1 
 mkdir Analysis
 cd Analysis
 ```

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -30,7 +30,6 @@
 <use name="HLTrigger/HLTcore"/>
 <use name="RecoEgamma/EgammaTools"/>
 <use name="RecoEgamma/ElectronIdentification"/>
-<use name="RecoMET/METFilters"/>
 <use name="RecoMET/METAlgorithms"/>
 <!--<use name="lhapdf"/>-->
 


### PR DESCRIPTION
For getting the 80X Electron IDs
`git cms-merge-topic -u ikrav:egm_id_80X_v1`

Removed MetFilters from the Buildfile
